### PR TITLE
Fix fail-fast dependency initialization

### DIFF
--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-redis/redis/v8"
 	"os"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis/v8"
 )
 
 type RedisCache struct {
@@ -16,13 +19,25 @@ type RedisCache struct {
 
 var ctx = context.Background()
 
-func NewRedisCache() *RedisCache {
-	redisAddr := os.Getenv("REDIS_ADDRESS")
+func NewRedisCache() (*RedisCache, error) {
+	redisAddr := strings.TrimSpace(os.Getenv("REDIS_ADDRESS"))
+	if redisAddr == "" {
+		return nil, errors.New("REDIS_ADDRESS environment variable is required")
+	}
+
 	client := redis.NewClient(&redis.Options{
 		Addr: redisAddr,
 	})
 
-	return &RedisCache{client: client}
+	pingCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	if err := client.Ping(pingCtx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("connect to Redis at %q: %w", redisAddr, err)
+	}
+
+	return &RedisCache{client: client}, nil
 }
 
 func (r *RedisCache) Get(key string) (models.Metadata, bool) {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -15,12 +15,28 @@ import (
 	"strings"
 )
 
-var s3Client = s3client.NewS3Client()
-var urlCache = cache.NewRedisCache()
+var s3Client *s3client.S3Client
+var urlCache *cache.RedisCache
 var downloadImages = downloader.DownloadImages
 var pageImageURLs = downloader.PageImageURLs
 
 const generateImageKeyErrorMessage = "Failed to generate image key"
+
+func InitDependencies() error {
+	var err error
+
+	s3Client, err = s3client.NewS3Client()
+	if err != nil {
+		return fmt.Errorf("initialize S3 client: %w", err)
+	}
+
+	urlCache, err = cache.NewRedisCache()
+	if err != nil {
+		return fmt.Errorf("initialize Redis cache: %w", err)
+	}
+
+	return nil
+}
 
 // CheckImages handles GET requests to check if images by URL already exist in S3
 func CheckImages(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"ImageCrawler/handlers"
+	"log"
+
 	"github.com/fufuok/favicon"
 	"github.com/gin-gonic/gin"
 	"github.com/penglongli/gin-metrics/ginmetrics"
 )
 
 func main() {
+	if err := handlers.InitDependencies(); err != nil {
+		log.Fatalf("failed to initialize dependencies: %v", err)
+	}
+
 	var favData []byte
 	r := gin.Default()
 

--- a/s3client/s3client.go
+++ b/s3client/s3client.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"io"
 	"os"
+	"strings"
 	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 type S3Client struct {
@@ -16,38 +18,63 @@ type S3Client struct {
 	BucketName string
 }
 
-func NewS3Client() *S3Client {
-	endpoint := os.Getenv("S3_ENDPOINT")
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	bucketName := os.Getenv("S3_BUCKET")
+func NewS3Client() (*S3Client, error) {
+	endpoint, err := requiredEnv("S3_ENDPOINT")
+	if err != nil {
+		return nil, err
+	}
+	accessKeyID, err := requiredEnv("AWS_ACCESS_KEY_ID")
+	if err != nil {
+		return nil, err
+	}
+	secretAccessKey, err := requiredEnv("AWS_SECRET_ACCESS_KEY")
+	if err != nil {
+		return nil, err
+	}
+	region, err := requiredEnv("AWS_REGION")
+	if err != nil {
+		return nil, err
+	}
+	bucketName, err := requiredEnv("S3_BUCKET")
+	if err != nil {
+		return nil, err
+	}
 
 	client, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
 		Secure: false,
 	})
 	if err != nil {
-		println(err)
+		return nil, fmt.Errorf("create S3 client: %w", err)
 	}
 
-	found, err := client.BucketExists(context.Background(), bucketName)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	found, err := client.BucketExists(ctx, bucketName)
 	if err != nil {
-		fmt.Println("No S3 storage found")
+		return nil, fmt.Errorf("check S3 bucket %q: %w", bucketName, err)
 	}
 
 	if !found {
-		err = client.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{Region: "us-east-1"})
+		err = client.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{Region: region})
 		if err != nil {
-			fmt.Println("No S3 storage found, can't create S3 bucket")
-		} else {
-			fmt.Println("Bucket created")
+			return nil, fmt.Errorf("create S3 bucket %q: %w", bucketName, err)
 		}
 	}
 
 	return &S3Client{
 		Client:     client,
 		BucketName: bucketName,
+	}, nil
+}
+
+func requiredEnv(name string) (string, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return "", fmt.Errorf("%s environment variable is required", name)
 	}
+	return value, nil
 }
 
 func (s *S3Client) PutObject(key string, data []byte) error {


### PR DESCRIPTION
Fixes #6.

## Changes
- Make `NewS3Client` return `(*S3Client, error)` and validate required S3/MinIO environment variables.
- Make `NewRedisCache` return `(*RedisCache, error)`, validate `REDIS_ADDRESS`, and `PING` Redis during initialization.
- Add `handlers.InitDependencies()` and call it from `main()` before registering routes/listening.
- Propagate initialization errors with context and fail fast via `log.Fatalf`.
- Use `AWS_REGION` for bucket creation instead of hardcoding the region.

## Validation
- Ran `gofmt` on changed Go files.
- Could not run `go test ./...` locally in this environment because the sandbox cannot resolve `github.com` to download/clone dependencies; CI should verify compilation/tests.