### PR TITLE
Add strict URL validation and SSRF protection

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"ImageCrawler/models"
+	"ImageCrawler/safeurl"
 	"fmt"
 	"golang.org/x/net/html"
 	"io"
@@ -10,6 +11,9 @@ import (
 	"sync"
 	"time"
 )
+
+// httpTimeout bounds each outbound request (page fetch or image download).
+const httpTimeout = 15 * time.Second
 
 func DownloadImages(pageURL string) ([]models.ImageBlob, error) {
 	imgURLs, err := PageImageURLs(pageURL)
@@ -20,11 +24,16 @@ func DownloadImages(pageURL string) ([]models.ImageBlob, error) {
 	var imageBlobs []models.ImageBlob
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	client := http.Client{Timeout: 15 * time.Second}
+	client := safeurl.NewSafeClient(httpTimeout)
 	for _, imgURL := range imgURLs {
 		wg.Add(1)
 		go func(imgURL string) {
 			defer wg.Done()
+
+			if err := safeurl.ValidateURL(imgURL); err != nil {
+				fmt.Printf("skipping image with invalid URL %q: %v\n", imgURL, err)
+				return
+			}
 
 			imgResp, err := client.Get(imgURL)
 			if err != nil {
@@ -65,7 +74,11 @@ func DownloadImages(pageURL string) ([]models.ImageBlob, error) {
 func PageImageURLs(pageURL string) ([]models.ImageUrl, error) {
 	var imageUrls []models.ImageUrl
 
-	client := http.Client{Timeout: 15 * time.Second}
+	if err := safeurl.ValidateURL(pageURL); err != nil {
+		return nil, fmt.Errorf("invalid page URL: %w", err)
+	}
+
+	client := safeurl.NewSafeClient(httpTimeout)
 	resp, err := client.Get(pageURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch page: %v", err)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"ImageCrawler/models"
+	"ImageCrawler/safeurl"
 	"crypto/md5"
 	"fmt"
 	"net/http"
@@ -77,6 +78,11 @@ func (h *Handler) ProcessURL(c *gin.Context) {
 		return
 	}
 
+	if err := safeurl.ValidateURL(req.URL); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid URL: %v", err)})
+		return
+	}
+
 	if h.cache.Exists(req.URL) {
 		c.JSON(http.StatusConflict, gin.H{"error": "URL already processed"})
 		return
@@ -111,6 +117,11 @@ func (h *Handler) UpdateURL(c *gin.Context) {
 	var req models.URLRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		return
+	}
+
+	if err := safeurl.ValidateURL(req.URL); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid URL: %v", err)})
 		return
 	}
 

--- a/safeurl/safeurl.go
+++ b/safeurl/safeurl.go
@@ -1,0 +1,180 @@
+// Package safeurl provides URL validation and an HTTP client hardened against
+// Server-Side Request Forgery (SSRF).
+//
+// There are two layers of defense:
+//
+//  1. ValidateURL performs cheap, synchronous checks on a user-supplied URL
+//     (scheme is http/https, a host is present, the host literal is not an
+//     obviously-internal address). This is meant for the API input layer so
+//     bad requests are rejected before any work is done.
+//
+//  2. NewSafeClient returns an *http.Client whose dialer inspects the *resolved*
+//     IP address of every connection (including those created while following
+//     redirects) and refuses to connect to loopback, private, link-local and
+//     other non-public ranges. Because the check happens at dial time, after
+//     DNS resolution, it is the authoritative defense: it closes the
+//     DNS-rebinding (TOCTOU) hole that a name- or parse-time-only check leaves
+//     open, and it cannot be bypassed by HTTP redirects.
+package safeurl
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// maxRedirects is the maximum number of redirects the safe client will follow.
+const maxRedirects = 5
+
+// ValidateURL performs cheap, synchronous validation of a user-supplied URL.
+//
+// It guarantees the URL is well-formed, uses an http or https scheme and has a
+// host. If the host is an IP literal it is checked against the disallowed
+// ranges immediately. Hostnames that resolve to internal addresses are caught
+// later, at dial time, by the client returned from NewSafeClient.
+func ValidateURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL must include a host")
+	}
+
+	// Reject well-known internal hostnames up front for a friendlier, faster
+	// failure. The dial-time check below is what actually enforces this.
+	if isInternalHostname(host) {
+		return fmt.Errorf("URL host %q is not allowed", host)
+	}
+
+	// If the host is an IP literal, reject disallowed ranges immediately.
+	if ip := net.ParseIP(host); ip != nil && isDisallowedIP(ip) {
+		return fmt.Errorf("URL host %q resolves to a disallowed address", host)
+	}
+
+	return nil
+}
+
+// NewSafeClient returns an *http.Client that is hardened against SSRF. The
+// supplied timeout bounds the whole request (including redirects); it should be
+// greater than zero.
+func NewSafeClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		// Control runs after DNS resolution but before the socket is dialed,
+		// on the concrete IP being connected to. This is what makes the
+		// protection robust against DNS rebinding and redirect-based bypasses.
+		Control: safeControl,
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 15 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: checkRedirect,
+	}
+}
+
+// checkRedirect limits the number of redirects and refuses to follow a redirect
+// to anything other than http/https. The destination IP is still validated by
+// safeControl when the next connection is dialed.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	switch req.URL.Scheme {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("redirect to unsupported scheme %q blocked", req.URL.Scheme)
+	}
+}
+
+// safeControl is installed as net.Dialer.Control. It receives the concrete
+// resolved address (host:port, host being an IP literal) and rejects the
+// connection if the IP is not publicly routable.
+func safeControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("dial address host %q is not an IP", host)
+	}
+	if isDisallowedIP(ip) {
+		return fmt.Errorf("connection to disallowed address %s blocked", ip)
+	}
+	return nil
+}
+
+// isInternalHostname catches a few common internal names cheaply. It is a
+// convenience, not a security boundary; the dial-time IP check is authoritative.
+func isInternalHostname(host string) bool {
+	h := strings.ToLower(strings.TrimSuffix(host, "."))
+	switch h {
+	case "localhost", "ip6-localhost", "ip6-loopback":
+		return true
+	}
+	return strings.HasSuffix(h, ".localhost")
+}
+
+// isDisallowedIP reports whether ip is in a range that must never be reached by
+// a user-controlled request (loopback, private, link-local, CGNAT, multicast,
+// unspecified, etc.).
+func isDisallowedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	// Normalize IPv4-in-IPv6 (e.g. ::ffff:127.0.0.1) to its IPv4 form so the
+	// checks below apply correctly.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+
+	if ip.IsUnspecified() || // 0.0.0.0, ::
+		ip.IsLoopback() || // 127.0.0.0/8, ::1
+		ip.IsPrivate() || // 10/8, 172.16/12, 192.168/16, fc00::/7
+		ip.IsLinkLocalUnicast() || // 169.254.0.0/16 (incl. 169.254.169.254), fe80::/10
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() {
+		return true
+	}
+
+	if v4 := ip.To4(); v4 != nil {
+		// Carrier-grade NAT 100.64.0.0/10 (RFC 6598) — not publicly routable.
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return true
+		}
+		// Limited broadcast 255.255.255.255.
+		if v4[0] == 255 && v4[1] == 255 && v4[2] == 255 && v4[3] == 255 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/safeurl/safeurl_test.go
+++ b/safeurl/safeurl_test.go
@@ -1,0 +1,134 @@
+package safeurl
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateURLAccepts(t *testing.T) {
+	valid := []string{
+		"http://example.com",
+		"https://example.com",
+		"https://example.com:8443/path?q=1",
+		"http://sub.domain.example.org/img.png",
+		"https://93.184.216.34/", // public IP literal
+	}
+	for _, u := range valid {
+		if err := ValidateURL(u); err != nil {
+			t.Errorf("ValidateURL(%q) = %v, want nil", u, err)
+		}
+	}
+}
+
+func TestValidateURLRejects(t *testing.T) {
+	invalid := []string{
+		"",                            // empty
+		"ftp://example.com",           // wrong scheme
+		"file:///etc/passwd",          // wrong scheme
+		"gopher://example.com",        // wrong scheme
+		"http://",                     // no host
+		"https:///path",               // no host
+		"http://localhost",            // internal name
+		"http://localhost:8080/admin", // internal name
+		"http://LOCALHOST",            // case-insensitive
+		"http://service.localhost",    // .localhost suffix
+		"http://127.0.0.1",            // loopback literal
+		"http://127.0.0.1:9000",       // loopback literal
+		"http://10.0.0.5",             // private
+		"http://172.16.0.1",           // private
+		"http://192.168.1.1",          // private
+		"http://169.254.169.254",      // cloud metadata (link-local)
+		"http://100.64.1.1",           // CGNAT
+		"http://0.0.0.0",              // unspecified
+		"http://[::1]",                // IPv6 loopback
+		"http://[fe80::1]",            // IPv6 link-local
+		"http://[::ffff:127.0.0.1]",   // IPv4-mapped loopback
+	}
+	for _, u := range invalid {
+		if err := ValidateURL(u); err == nil {
+			t.Errorf("ValidateURL(%q) = nil, want error", u)
+		}
+	}
+}
+
+func TestIsDisallowedIP(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1":        true,
+		"10.1.2.3":         true,
+		"172.20.5.5":       true,
+		"192.168.0.1":      true,
+		"169.254.169.254":  true,
+		"100.64.0.1":       true,
+		"100.127.255.255":  true,
+		"0.0.0.0":          true,
+		"255.255.255.255":  true,
+		"224.0.0.1":        true, // multicast
+		"::1":              true,
+		"fe80::1":          true,
+		"fc00::1":          true,
+		"::ffff:10.0.0.1":  true, // IPv4-mapped private
+		"8.8.8.8":          false,
+		"93.184.216.34":    false,
+		"1.1.1.1":          false,
+		"100.63.255.255":   false, // just below CGNAT
+		"100.128.0.0":      false, // just above CGNAT
+		"2606:4700:4700::": false, // public IPv6 (Cloudflare)
+	}
+	for s, want := range cases {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("could not parse test IP %q", s)
+		}
+		if got := isDisallowedIP(ip); got != want {
+			t.Errorf("isDisallowedIP(%s) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+func TestSafeClientBlocksLoopback(t *testing.T) {
+	// httptest servers always listen on loopback, so a hardened client must
+	// refuse to connect to one.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewSafeClient(5 * time.Second)
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatalf("expected the safe client to block a loopback request to %s", srv.URL)
+	}
+	if !strings.Contains(err.Error(), "disallowed") {
+		t.Errorf("expected a 'disallowed address' error, got: %v", err)
+	}
+}
+
+func TestCheckRedirectLimit(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+
+	via := make([]*http.Request, maxRedirects-1)
+	if err := checkRedirect(req, via); err != nil {
+		t.Errorf("redirect %d should be allowed, got: %v", len(via), err)
+	}
+
+	via = make([]*http.Request, maxRedirects)
+	if err := checkRedirect(req, via); err == nil {
+		t.Errorf("redirect %d should be blocked", len(via))
+	}
+}
+
+func TestCheckRedirectScheme(t *testing.T) {
+	bad, _ := http.NewRequest(http.MethodGet, "file:///etc/passwd", nil)
+	if err := checkRedirect(bad, nil); err == nil {
+		t.Errorf("redirect to file:// scheme should be blocked")
+	}
+
+	good, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err := checkRedirect(good, nil); err != nil {
+		t.Errorf("redirect to https:// should be allowed, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #8.

Adds a safeurl package with two layers of SSRF defense: ValidateURL for
http/https-only input validation wired into the POST/PUT handlers, and
NewSafeClient, an http.Client that validates the resolved IP at dial
time (net.Dialer.Control) -- closing DNS-rebinding and covering redirects
(capped at 5, http/https only). The downloader now uses this client and
validates every URL. Blocked ranges: loopback, RFC1918 private,
link-local incl. 169.254.169.254, CGNAT 100.64.0.0/10, unspecified,
multicast, broadcast, and IPv4-mapped equivalents. safeurl has
stdlib-only unit tests. Note: handlers_test.go appears out of sync with
handlers.go (pre-existing) and may need a separate fix.